### PR TITLE
Fixing invalid intensity bug

### DIFF
--- a/src/max7219/driver-implementation/basic-contorl.md
+++ b/src/max7219/driver-implementation/basic-contorl.md
@@ -85,6 +85,9 @@ pub fn set_intensity(&mut self, device_index: usize, intensity: u8) -> Result<()
 }
 
 pub fn set_intensity_all(&mut self, intensity: u8) -> Result<()> {
+    if intensity > 0x0F {
+        return Err(Error::InvalidIntensity);
+    }
     let ops = [(Register::Intensity, intensity); MAX_DISPLAYS];
     self.write_all_registers(&ops[..self.device_count])
 }


### PR DESCRIPTION
Howdy,

I found a small bug while reading the book. It's possible to set an invalid intensity when using Max7219::set_intensity_all. I fixed the bug. Also submitted a PR on the code repo.